### PR TITLE
Enclose database queries in transactions.

### DIFF
--- a/lib/AMC/Export/ItemAnalysis.pm
+++ b/lib/AMC/Export/ItemAnalysis.pm
@@ -112,6 +112,8 @@ sub pre_process {
     $self->{'submissions'} = [];
     $exam_name = $self->{'out.nom'} ? $self->{'out.nom'} : "Untitled Exam" ;
 
+    $self->{'_scoring'}->begin_read_transaction('IAgt');
+    
     $marks = $self->{'marks'};
     my @codes;
     my @questions;
@@ -123,6 +125,10 @@ sub pre_process {
     #
     # Do we need @codes?
     $self->codes_questions(\@codes,\@questions,1);
+    for my $question (@questions) {
+       $question->{'ceiling'} = $self->{'_scoring'}->
+           question_maxmax($question->{'question'});
+    }
     $self->{'questions'} = \@questions;
 
     # look for the first mark that has a max
@@ -165,6 +171,8 @@ sub pre_process {
         }
         push @{$self->{'submissions'}}, $submission;
     }
+
+    $self->{'_scoring'}->end_transaction('IAgt');
 
     # exam summary statistics and metadata
     $self->{'summary'} = {};
@@ -270,7 +278,6 @@ sub weight_student_scoring_base {
 #           (I think this can be found in student_scoring_base)
 sub analyze {
     my ($self) = @_;
-    $scoring = $self->{'_scoring'};
 
     # analyze the total     
     $marks = $self->{'marks'};
@@ -283,12 +290,10 @@ sub analyze {
     # analyze each question
     for my $question (@{$self->{'questions'}}) {
         $title = $question->{'title'};
-        $number = $question->{'question'};
         @question_scores = map {$_->{$title}->{'score'}} @{$self->{'submissions'}};
         $question_stats = Statistics::Descriptive::Full->new();
         $question_stats->add_data(@question_scores);
         $self->compute_summary_statistics($question_stats,$question);        
-        $question->{'ceiling'} = $scoring->question_maxmax($number);
        	if ($question->{'ceiling'} != 0) {
             $question->{'difficulty'} = $question->{'mean'} / $question->{'ceiling'};
             $question->{'difficulty_class'} = $self->classify_difficulty($question);


### PR DESCRIPTION
This way the data can't be changed during the computations, and the debugging mode won't complain that transactions are missing.
The name of the transaction ('IAgt') is arbitrary. Usualy it's a 4-characters name. I chose something inspired by " Item Analysis GeT ".